### PR TITLE
Update main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -139,6 +139,7 @@ for i in range(4, 523):
       pos = 0
       ayah = ayah + 1
       for l in range(line, num_lines):
+         cur_line =  lines[l]
          pos = pos + 1
          maxx = cur_line[1][0]
          if x_pos_in_line > 0:


### PR DESCRIPTION
The problem is when last verse of page is not ended at this page and has more than one line glyph, all glyphs insert statements are written to be in first line of verse. The solution was updating value of cur_line, so glyphs insert statements get the correct line number.

This Problem won't appear no verse can continue at next page like in Moshaf Madina. It only appears for verse continue in next page and has more than one line at that starting page. 
